### PR TITLE
Fix little error on Jaro Similarity

### DIFF
--- a/simmetrics/jaro.c
+++ b/simmetrics/jaro.c
@@ -48,7 +48,7 @@ static char *get_common_chars(const char *str1, const char *str2,
 		char tmp = str1[i];
 
 		int max = MAX(0, (i - d_step));
-		int min = MIN(i + d_step, ((int)strlen(str2) - 1));
+		int min = MIN(i + d_step, (int)strlen(str2) );
 
 		for (j = max; j < min; j++) {
 


### PR DESCRIPTION
This error cause break during execution time, and comparing this
situation with version in .NET:
.Net: Math.Min(i + distanceSep, secondWord.Length);

C: int min = MIN(i + d_step, ((int)strlen(str2) - 1));  (error !)
C: int min = MIN(i + d_step, (int)strlen(str2) ); (correct !)

Thank!
